### PR TITLE
Include missing mainloop-glib.c

### DIFF
--- a/bluez-5.5/btgatt-server.c
+++ b/bluez-5.5/btgatt-server.c
@@ -38,6 +38,7 @@
 #include "lib/uuid.h"
 
 #include "src/shared/mainloop.h"
+#include "src/shared/mainloop-glib.c"
 #include "src/shared/util.h"
 #include "src/shared/att.h"
 #include "src/shared/queue.h"


### PR DESCRIPTION
I couldn't get bluez compiled without this include. It was complaining about missing definition of mainloop_set_signal method.